### PR TITLE
fix: add zero check of day field in is_zeroed of IntervalNorm

### DIFF
--- a/src/interval_norm.rs
+++ b/src/interval_norm.rs
@@ -81,6 +81,7 @@ impl IntervalNorm {
     pub fn is_zeroed(&self) -> bool {
         self.years == 0
             && self.months == 0
+            && self.days == 0
             && self.hours == 0
             && self.minutes == 0
             && self.seconds == 0

--- a/src/pg_interval.rs
+++ b/src/pg_interval.rs
@@ -313,6 +313,13 @@ mod tests {
     }
 
     #[test]
+    fn test_postgres_19(){
+        let interval = Interval::new(0, 3, 0);
+        let output = interval.to_postgres();
+        assert_eq!(String::from("3 days"), output);
+    }
+
+    #[test]
     fn test_sql_1() {
         let interval = Interval::new(12, 0, 0);
         let output = interval.to_sql();


### PR DESCRIPTION
This PR fix #70 , it 
- add zero check of day field 
- add a unit test for this PR 