### PR TITLE
chore: bump to 2021 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pg_interval"
-version = "0.4.3"
-edition = "2018"
+version = "0.4.4"
+edition = "2021"
 authors = ["Ryan Piper <piper.ryan235@gmail.com>"]
 license = "MIT"
 description = "A native PostgreSQL interval type"


### PR DESCRIPTION
Closes #68

Ran `cargo fix --edition` and `cargo fix --edition-idioms` before incrementing the cargo edition value. 